### PR TITLE
#163075084 Integrate Travis CI Badge to Show Build Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 
+[![Build Status](https://travis-ci.org/hogum/qstioner-api.svg?branch=develop)](https://travis-ci.org/hogum/qstioner-api)
+[![Coverage Status](https://coveralls.io/repos/github/hogum/qstioner-api/badge.svg?branch=ch-ci-badges-163075084)](https://coveralls.io/github/hogum/qstioner-api?branch=ch-ci-badges-163075084)
+[![Maintainability](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/maintainability)](https://codeclimate.com/github/codeclimate/codeclimate/maintainability)
+
+[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/faa1bb2518cd81a3e91d)
 
 # qstioner-api
 Questioner api is an api version 1 of the qstioner web application. It allows the user to send htttp requests to application and persists in data structures


### PR DESCRIPTION
#### What does this PR do?
Creates badges for display on the repo's readMe

#### Description of Task to be completed?
Have an easy way to show the CI integration of the project

#### How should this be manually tested?

1. Access the repo on github [here](https://github.com/hogum/qstioner-api)
2. The badges will be visible on the readme.md file

#### Any background context you want to provide?
THe badges will display the build status of the application and code test coverage for written tests.
Tests pass locally, which prompts us to expect a passing build on travis.

#### What are the relevant pivotal tracker stories?
[163075084](https://www.pivotaltracker.com/story/show/163075084)

