### PR TITLE
#163075084 Space out CI Badges Display on ReadMe for a More Elegant Layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Build Status](https://travis-ci.org/hogum/qstioner-api.png?branch=develop)](https://travis-ci.org/hogum/qstioner-api)[![Coverage Status](https://coveralls.io/repos/github/hogum/qstioner-api/badge.svg?branch=ch-ci-badges-163075084)](https://coveralls.io/github/hogum/qstioner-api?branch=ch-ci-badges-163075084)
+[![Build Status](https://travis-ci.org/hogum/qstioner-api.png?branch=develop)](https://travis-ci.org/hogum/qstioner-api) [![Coverage Status](https://coveralls.io/repos/github/hogum/qstioner-api/badge.svg?branch=ch-ci-badges-163075084)](https://coveralls.io/github/hogum/qstioner-api?branch=ch-ci-badges-163075084)
 [![Maintainability](https://api.codeclimate.com/v1/badges/a99a88d28ad37a79dbf6/maintainability)](https://codeclimate.com/github/codeclimate/codeclimate/maintainability)
 
 [![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/faa1bb2518cd81a3e91d)


### PR DESCRIPTION
#### What does this PR do?
Space Out the badges displayed on the repo's readMe file

#### Description of Task to be completed?
- Have the CI badges evenly displayed
- Ensure the badges do not overlap each other
#### How should this be manually tested?

1. Access the repo on github [here](https://github.com/hogum/qstioner-api)
2. The badges will be visible on the readme.md file

#### Any background context you want to provide?
THe badges will display the build status of the application and code test coverage for written tests.
Tests pass locally, which prompts us to expect a passing build on travis.

#### What are the relevant pivotal tracker stories?
[163075084](https://www.pivotaltracker.com/story/show/163075084)

#### Screenshots

![screenshot from 2019-01-09 02-38-36](https://user-images.githubusercontent.com/44059971/50865301-33782c00-13b6-11e9-857c-1f7df17817d8.png)
