### PR TITLE
#163154676 Fetch Meetups RSVP-ed by a  User

### DIFF
--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -4,7 +4,7 @@ from flask import Blueprint
 from ...api.v1.views.user import UsersRegistration, UserLogin, UserLogout
 from ...api.v1.views.meetups import Meetups, MeetUp, MeetUpItem
 from ...api.v1.views.questions import Question, Questions, QuestionVote
-from ...api.v1.views.rsvp import Rsvps
+from ...api.v1.views.rsvp import Rsvps, Rsvp
 
 auth_blueprint = Blueprint("auth", __name__, url_prefix='/api/v1/auth/')
 app_blueprint = Blueprint("app", __name__, url_prefix='/api/v1/')
@@ -24,3 +24,4 @@ app_api.add_resource(Question, 'questions/<int:id>')
 app_api.add_resource(QuestionVote, 'questions/<int:id>/<vote>',
                      methods=['PATCH'])
 app_api.add_resource(Rsvps, 'meetups/<int:id>/<response>')
+app_api.add_resource(Rsvp, 'meetups/<int:id>/rsvp', 'meetups/<username>/rsvp')

--- a/app/api/v1/models/meetups.py
+++ b/app/api/v1/models/meetups.py
@@ -4,8 +4,6 @@
 
 from ..models.abstract_model import AbstractModel
 
-meetups = []  # Holds all meetups records
-
 
 class MeetUpModel(AbstractModel):
 
@@ -71,3 +69,6 @@ class MeetUpModel(AbstractModel):
 
     def __repr__(self):
         return '{topic} {tags} {location}'.format(**self.dictify())
+
+
+meetups = []  # Holds all meetups records

--- a/app/api/v1/models/rsvp.py
+++ b/app/api/v1/models/rsvp.py
@@ -53,7 +53,7 @@ class RsvpModel(AbstractModel):
                     if repr(rsvp) == repr(rsvp_object)])
 
     def __repr__(self):
-        return '{response} {meetup} {user}'.format(**self.dictify())
+        return '{meetup} {user}'.format(**self.dictify())
 
 
 rsvps = []

--- a/app/api/v1/models/rsvp.py
+++ b/app/api/v1/models/rsvp.py
@@ -33,11 +33,14 @@ class RsvpModel(AbstractModel):
         # Searches
 
     @classmethod
-    def get_all_rsvps(cls):
+    def get_all_rsvps(cls, obj=False):
         """
             Converts all present rsvp objects to a
             dictionary and sends them in a list envelope
         """
+        if obj:
+            return [rsvp for rsvp in rsvps]
+
         return [rsvp.dictify() for rsvp in rsvps]
 
     @classmethod

--- a/app/api/v1/utils/helpers.py
+++ b/app/api/v1/utils/helpers.py
@@ -48,6 +48,12 @@ def current_user_only(f):
         user = url_user_field[-2]
         this_user = get_jwt_identity()
 
+        if not this_user:
+            return {
+                "Status": 403,
+                "Message": "You need to be logged in to do that"
+            }
+
         try:
             uid = int(user)
             user = [usr for usr in
@@ -61,19 +67,3 @@ def current_user_only(f):
             }, 403
         return f(*args, **kwars)
     return wrapper
-
-
-def check_user(user):
-    this_user = get_jwt_identity()
-
-    try:
-        uid = int(user)
-        user = [usr for usr in
-                UserModel.get_all_users() if user['id'] == uid]
-    except ValueError:
-        user = user
-    if this_user != user:
-        return {
-            "Status": 403,
-            "Error": "Denied. Not accessible to current user"
-        }, 403

--- a/app/api/v1/utils/helpers.py
+++ b/app/api/v1/utils/helpers.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from flask import request
 
 from ...v1.models.users import UserModel
 from ...v1.views.user import get_jwt_identity
@@ -38,3 +39,20 @@ def admin_required(f):
             }, 403
         return f(*args, **kwargs)
     return wrapper
+
+
+def current_user_only(f):
+    wraps(f)
+
+    def wrapper(*args, **kwars):
+        url_user_field = request.base_url.split('/')[-2]
+        check_user(url_user_field)
+
+
+def check_user(user):
+    this_user = get_jwt_identity()
+    if this_user is not user:
+        return {
+            "Status": 403,
+            "Error": "Denied. Not accessible to current user"
+        }, 403

--- a/app/api/v1/utils/helpers.py
+++ b/app/api/v1/utils/helpers.py
@@ -45,6 +45,7 @@ def current_user_only(f):
     @wraps(f)
     def wrapper(*args, **kwars):
         url_user_field = request.base_url.split('/')[-2]
+        print(request.base_url)
         check_user(url_user_field)
         return f(*args, **kwars)
     return wrapper
@@ -53,10 +54,13 @@ def current_user_only(f):
 def check_user(user):
     this_user = get_jwt_identity()
 
-    if len(user) == 1:
+    try:
+        uid = int(user)
         user = [usr for usr in
-                UserModel.get_all_users() if user.get('id') == int(user)]
-    if this_user is not user:
+                UserModel.get_all_users() if user['id'] == uid]
+    except ValueError:
+        user = user
+    if this_user != user:
         return {
             "Status": 403,
             "Error": "Denied. Not accessible to current user"

--- a/app/api/v1/utils/helpers.py
+++ b/app/api/v1/utils/helpers.py
@@ -42,11 +42,12 @@ def admin_required(f):
 
 
 def current_user_only(f):
-    wraps(f)
-
+    @wraps(f)
     def wrapper(*args, **kwars):
         url_user_field = request.base_url.split('/')[-2]
         check_user(url_user_field)
+        return f(*args, **kwars)
+    return wrapper
 
 
 def check_user(user):

--- a/app/api/v1/utils/helpers.py
+++ b/app/api/v1/utils/helpers.py
@@ -51,6 +51,10 @@ def current_user_only(f):
 
 def check_user(user):
     this_user = get_jwt_identity()
+
+    if len(user) == 1:
+        user = [usr for usr in
+                UserModel.get_all_users() if user.get('id') == int(user)]
     if this_user is not user:
         return {
             "Status": 403,

--- a/app/api/v1/utils/helpers.py
+++ b/app/api/v1/utils/helpers.py
@@ -44,9 +44,21 @@ def admin_required(f):
 def current_user_only(f):
     @wraps(f)
     def wrapper(*args, **kwars):
-        url_user_field = request.base_url.split('/')[-2]
-        print(request.base_url)
-        check_user(url_user_field)
+        url_user_field = request.base_url.split('/')
+        user = url_user_field[-2]
+        this_user = get_jwt_identity()
+
+        try:
+            uid = int(user)
+            user = [usr for usr in
+                    UserModel.get_all_users() if usr.get('id') == uid]
+        except ValueError:
+            user = user
+        if this_user != user:
+            return {
+                "Status": 403,
+                "Error": "Denied. Not accessible to current user"
+            }, 403
         return f(*args, **kwars)
     return wrapper
 

--- a/app/api/v1/views/rsvp.py
+++ b/app/api/v1/views/rsvp.py
@@ -75,12 +75,15 @@ class Rsvps(Resource):
             Allows the current user to see every existing
             meetups s/he has responded to an rsvp for
         """
+        # Find none 'None' ulr
         query_parameter = next(item for item in [id, username]
                                if item is not None)
+        # Get user id
+        # Rsvp stores user by id
         if username:
             query_parameter = UserModel.get_by_name(username).id
 
         rsvps = RsvpModel.get_all_rsvps()
 
-        [rsvp for rsvp in rsvps
-         if rsvp.get('user') == query_parameter]
+        users_rsvps = [rsvp for rsvp in rsvps
+                       if rsvp.get('user') == query_parameter]

--- a/app/api/v1/views/rsvp.py
+++ b/app/api/v1/views/rsvp.py
@@ -75,5 +75,12 @@ class Rsvps(Resource):
             Allows the current user to see every existing
             meetups s/he has responded to an rsvp for
         """
+        query_parameter = next(item for item in [id, username]
+                               if item is not None)
+        if username:
+            query_parameter = UserModel.get_by_name(username).id
 
-        rsvps = RsvpModel.get_all_rsvps(obj=True)
+        rsvps = RsvpModel.get_all_rsvps()
+
+        [rsvp for rsvp in rsvps
+         if rsvp.get('user') == query_parameter]

--- a/app/api/v1/views/rsvp.py
+++ b/app/api/v1/views/rsvp.py
@@ -75,7 +75,9 @@ class Rsvps(Resource):
             Allows the current user to see every existing
             meetups s/he has responded to an rsvp for
         """
+
         # Find none 'None' ulr
+
         query_parameter = next(item for item in [id, username]
                                if item is not None)
         # Get user id
@@ -83,7 +85,13 @@ class Rsvps(Resource):
         if username:
             query_parameter = UserModel.get_by_name(username).id
 
-        rsvps = RsvpModel.get_all_rsvps()
+        rsvps = RsvpModel.get_all_rsvps(obj=True)
 
         users_rsvps = [rsvp for rsvp in rsvps
-                       if rsvp.get('user') == query_parameter]
+                       if getattr(rsvp, 'user') == query_parameter]
+
+        # Find all these rsvp-ed meetups
+        meetups = [item.id for item in users_rsvps]
+
+        return {"Status": 200,
+                "Data": meetups}, 200

--- a/app/api/v1/views/rsvp.py
+++ b/app/api/v1/views/rsvp.py
@@ -69,3 +69,11 @@ class Rsvps(Resource):
             "Status": 201,
             "Data": rsvp.dictify()
         }, 201
+
+    def get(self, meetup, id=None, username=None):
+        """
+            Allows the current user to see every existing
+            meetups s/he has responded to an rsvp for
+        """
+
+        rsvps = RsvpModel.get_all_rsvps(obj=True)

--- a/app/api/v1/views/rsvp.py
+++ b/app/api/v1/views/rsvp.py
@@ -95,6 +95,8 @@ class Rsvp(Resource):
 
         # Find all these rsvp-ed meetups
         meetups = [item.id for item in users_rsvps]
+        meetups_data = list(map(lambda x: MeetUpModel.get_by_id(x), meetups))
 
         return {"Status": 200,
-                "Data": meetups}, 200
+                "Data": [(id + 1, data) for id, data
+                         in enumerate(meetups_data)]}, 200

--- a/app/api/v1/views/rsvp.py
+++ b/app/api/v1/views/rsvp.py
@@ -70,7 +70,7 @@ class Rsvps(Resource):
             "Data": rsvp.dictify()
         }, 201
 
-    def get(self, meetup, id=None, username=None):
+    def get(self, id=None, username=None):
         """
             Allows the current user to see every existing
             meetups s/he has responded to an rsvp for

--- a/app/api/v1/views/rsvp.py
+++ b/app/api/v1/views/rsvp.py
@@ -3,7 +3,7 @@
     rsvp Resource
 """
 
-from flask_restful import Resource, reqparse
+from flask_restful import Resource
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from ..models.rsvp import RsvpModel
@@ -69,6 +69,9 @@ class Rsvps(Resource):
             "Status": 201,
             "Data": rsvp.dictify()
         }, 201
+
+
+class Rsvp(Resource):
 
     def get(self, id=None, username=None):
         """


### PR DESCRIPTION
#### What does this PR do?
Allow a user with log in access to see the Meetups they have responded an RSVP to

#### Description of Task to be completed?

Ensure that the the following endpoint is functional and works as intended:
##### - GET `api/v1/meetups/<int:user_id>/<rsvp>`
or on a different Url
##### - GET `api/v1/meetups/<user_name>/rsvp`

- An rsvp response can be viewed, and its corresponding meetup by the user who created the rsvp

#### How should this be manually tested?

1. Clone this repo into your machine
``` shell
$ git clone https://github.com/hogum/qstioner-api.git
```
2. Navigate to the repo directory
``` shell
$ cd qstioner
```
3. Setup a virtual environment and install the project requirements
``` shell
$ pip3 install virtualenvwrapper
```
 ``` shell
$ source virtualenvwrapper.sh
```
``` shell
$ mkvirtuanenv pyenv && pip install -r requirements.txt 
```
4. Checkout this Feature branch:
``` shell
$ git checkout ft-rsvp-meetup-163154676
```
5. Test the endpoint `api/v1/meetups/<user_id>/rsvp`
- First, create a meetup - The first meetup will have an id of '1'
- Send an RSVP to the meetup
The endpoints for doing this are given [here](https://github.com/hogum/qstioner-api/blob/develop/README.md)
- Using the meetup's id, send a POST request to that endpoint with PostMan or Curl

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[163154676](https://www.pivotaltracker.com/story/show/163154676)


#### Screenshots

###### - RSVP the meetup

![screenshot from 2019-01-11 23-54-44](https://user-images.githubusercontent.com/44059971/51061779-6bc17980-1605-11e9-8e09-fd804e29d036.png)

###### - Get Meetups with RSVPs by the current user

![screenshot from 2019-01-11 23-54-21](https://user-images.githubusercontent.com/44059971/51061894-d5418800-1605-11e9-9470-3e77f48acc9c.png)
