### PR TITLE
#163178383 Fix Token Revoking on User Logout

### DIFF
--- a/app/api/v1/models/meetups.py
+++ b/app/api/v1/models/meetups.py
@@ -48,25 +48,22 @@ class MeetUpModel(AbstractModel):
         return [meetup.dictify() for meetup in meetups]
 
     @classmethod
-    def get_by_id(cls, given_id, obj=False):
+    def get_by_id(cls, given_id):
         """
             Searches and returns a meetup instance
             with an 'id' attribute matching the given id.
         """
-        if not obj:
-            that_meetup = [meetup.dictify() for meetup in meetups
-                           if getattr(meetup, 'id') == given_id]
-        else:
-            that_meetup = [meetup for meetup in meetups
-                           if getattr(meetup, 'id') == given_id]
+        that_meetup = [meetup.dictify() for meetup in meetups
+                       if getattr(meetup, 'id') == given_id]
 
         return that_meetup[0] if that_meetup else None
 
-    def delete(self):
+    @classmethod
+    def delete(self, id):
         """
             Permanently removes a meetup from the records.
         """
-        meetups.remove([x for x in meetups if x == self][0])
+        meetups.remove([x for x in meetups if getattr(x, 'id') == id][0])
 
     @classmethod
     def verify_unique(cls, meetup_object):

--- a/app/api/v1/models/meetups.py
+++ b/app/api/v1/models/meetups.py
@@ -48,13 +48,17 @@ class MeetUpModel(AbstractModel):
         return [meetup.dictify() for meetup in meetups]
 
     @classmethod
-    def get_by_id(cls, given_id):
+    def get_by_id(cls, given_id, obj=False):
         """
             Searches and returns a meetup instance
             with an 'id' attribute matching the given id.
         """
-        that_meetup = [meetup.dictify() for meetup in meetups
-                       if getattr(meetup, 'id') == given_id]
+        if not obj:
+            that_meetup = [meetup.dictify() for meetup in meetups
+                           if getattr(meetup, 'id') == given_id]
+        else:
+            that_meetup = [meetup for meetup in meetups
+                           if getattr(meetup, 'id') == given_id]
 
         return that_meetup[0] if that_meetup else None
 

--- a/app/api/v1/models/meetups.py
+++ b/app/api/v1/models/meetups.py
@@ -58,6 +58,12 @@ class MeetUpModel(AbstractModel):
 
         return that_meetup[0] if that_meetup else None
 
+    def delete(self):
+        """
+            Permanently removes a meetup from the records.
+        """
+        meetups.remove([x for x in meetups if x == self][0])
+
     @classmethod
     def verify_unique(cls, meetup_object):
         """

--- a/app/api/v1/models/meetups.py
+++ b/app/api/v1/models/meetups.py
@@ -48,22 +48,25 @@ class MeetUpModel(AbstractModel):
         return [meetup.dictify() for meetup in meetups]
 
     @classmethod
-    def get_by_id(cls, given_id):
+    def get_by_id(cls, given_id, obj=False):
         """
             Searches and returns a meetup instance
             with an 'id' attribute matching the given id.
         """
-        that_meetup = [meetup.dictify() for meetup in meetups
-                       if getattr(meetup, 'id') == given_id]
+        if not obj:
+            that_meetup = [meetup.dictify() for meetup in meetups
+                           if getattr(meetup, 'id') == given_id]
+        else:
+            that_meetup = [meetup for meetup in meetups
+                           if getattr(meetup, 'id') == given_id]
 
         return that_meetup[0] if that_meetup else None
 
-    @classmethod
-    def delete(self, id):
+    def delete(self):
         """
             Permanently removes a meetup from the records.
         """
-        meetups.remove([x for x in meetups if getattr(x, 'id') == id][0])
+        meetups.remove([x for x in meetups if x == self][0])
 
     @classmethod
     def verify_unique(cls, meetup_object):

--- a/app/api/v1/models/tokens.py
+++ b/app/api/v1/models/tokens.py
@@ -16,7 +16,7 @@ class Token:
     @classmethod
     def check_if_blacklisted(cls, given_token):
         return [token for token in blacklisted_tokens if
-                getattr(token, 'signature') == str(given_token)]
+                getattr(token, 'signature') == given_token]
 
 
 blacklisted_tokens = set()

--- a/app/api/v1/models/users.py
+++ b/app/api/v1/models/users.py
@@ -96,11 +96,6 @@ class UserModel(AbstractModel):
             payload = jwt.decode(encoded_token,
                                  app.config.get('SECRET_KEY'),
                                  algorithms='HS256')
-            if Token.check_if_blacklisted(payload):
-                return {
-                    "Status": 400,
-                    "Message": "Token unsuable. Try signing in again"
-                }, 400
             return payload['sub']
 
         except (jwt.ExpiredSignatureError, jwt.InvalidTokenError) as er:

--- a/app/api/v1/utils/auth.py
+++ b/app/api/v1/utils/auth.py
@@ -61,21 +61,33 @@ def current_user_only(f):
 
         # Comment out if manually testing
         # Handled by missing auth header error
-        """
+
         if not this_user:
             return {
                 "Status": 403,
                 "Message": "You need to be logged in to do that"
             }, 403
-        """
 
         try:
             uid = int(user)
             user = UserModel.get_by_id(uid)
             if user:
                 user = user.username
+            else:
+                return {
+                    "Status": 404,
+                    "Error": "User id does not exist. Provide a valid id"
+                }, 404
+
         except ValueError:
             user = user
+            if not UserModel.get_by_name(user):
+                return {
+                    "Status": 404,
+                    "Error": "Username not registered. \
+                    Provide a valid username"
+                }, 404
+
         if this_user != user:
             return {
                 "Status": 403,

--- a/app/api/v1/utils/auth.py
+++ b/app/api/v1/utils/auth.py
@@ -7,6 +7,7 @@ from functools import wraps
 from flask import request
 
 from ...v1.models.users import UserModel
+from ..models.tokens import Token
 
 current_user = None
 raw_auth = None
@@ -124,6 +125,12 @@ def auth_required(f):
             return {
                 "Status": 400,
                 "Message": "Token is empty. Please provide a valid token"
+            }, 400
+
+        if Token.check_if_blacklisted(payload):
+            return {
+                "Status": 400,
+                "Message": "Token unsuable. Try signing in again"
             }, 400
 
         try:

--- a/app/api/v1/views/docs/meetup_delete.yml
+++ b/app/api/v1/views/docs/meetup_delete.yml
@@ -12,7 +12,7 @@ parameters:
   type: string
   required: true
 - in: path
-  name: Meetup_id
+  name: id
   type: integer
   required: true
   description: The id of the Meetup to delete.

--- a/app/api/v1/views/docs/meetup_delete.yml
+++ b/app/api/v1/views/docs/meetup_delete.yml
@@ -22,6 +22,6 @@ responses:
   400:
     description: Bad Request. Validation failed
   403:
-    description: Unauthorized, response when Attendant tries to delete a Meetup
+    description: Unauthorized, response when anauthorized user tries to delete a Meetup
   404:
     description: Returned when Meetup with id specified does not exist.

--- a/app/api/v1/views/meetups.py
+++ b/app/api/v1/views/meetups.py
@@ -81,14 +81,14 @@ class MeetUpItem(Resource):
     @auth_required
     @swag_from('docs/meetup_delete.yml')
     def delete(this_user, self, id):
-        meetup = MeetUpModel.get_by_id(id, obj=True)
+        meetup = MeetUpModel.get_by_id(id)
         if not meetup:
             return {
                 "Status": 404,
                 "Error": "Meetup non-existent"
             }, 404
         else:
-            meetup.delete()
+            MeetUpModel.delete(id)
         return {
             "Status": 200,
             "Message": "MeetUp deleted"

--- a/app/api/v1/views/meetups.py
+++ b/app/api/v1/views/meetups.py
@@ -3,7 +3,7 @@ from flasgger import swag_from
 import datetime
 
 from ..models.meetups import MeetUpModel
-from ..utils.auth import admin_required, auth_required
+from ..utils.auth import admin_required, auth_required, current_user_only
 from ..utils.helpers import validate_date
 
 
@@ -76,4 +76,18 @@ class MeetUpItem(Resource):
         return {
             "Status": 200,
             "Data": [MeetUpModel.get_by_id(id)]
+        }, 200
+
+    @auth_required
+    @current_user_only
+    @swag_from('docs/meetup_delete.yml')
+    def delete(this_user, self, id):
+        if not MeetUpModel.get_by_id(id):
+            return {
+                "Status": 404,
+                "Error": "Meetup non-existent"
+            }, 404
+        return {
+            "Status": 200,
+            "Message": "MeetUp deleted"
         }, 200

--- a/app/api/v1/views/meetups.py
+++ b/app/api/v1/views/meetups.py
@@ -82,13 +82,14 @@ class MeetUpItem(Resource):
     @current_user_only
     @swag_from('docs/meetup_delete.yml')
     def delete(this_user, self, id):
-        if not MeetUpModel.get_by_id(id):
+        meetup = MeetUpModel.get_by_id(id)
+        if not meetup:
             return {
                 "Status": 404,
                 "Error": "Meetup non-existent"
             }, 404
         else:
-            MeetUpModel.delete(id)
+            meetup.delete()
         return {
             "Status": 200,
             "Message": "MeetUp deleted"

--- a/app/api/v1/views/meetups.py
+++ b/app/api/v1/views/meetups.py
@@ -81,14 +81,14 @@ class MeetUpItem(Resource):
     @auth_required
     @swag_from('docs/meetup_delete.yml')
     def delete(this_user, self, id):
-        meetup = MeetUpModel.get_by_id(id)
+        meetup = MeetUpModel.get_by_id(id, obj=True)
         if not meetup:
             return {
                 "Status": 404,
                 "Error": "Meetup non-existent"
             }, 404
         else:
-            MeetUpModel.delete(id)
+            meetup.delete()
         return {
             "Status": 200,
             "Message": "MeetUp deleted"

--- a/app/api/v1/views/meetups.py
+++ b/app/api/v1/views/meetups.py
@@ -79,7 +79,6 @@ class MeetUpItem(Resource):
         }, 200
 
     @auth_required
-    @current_user_only
     @swag_from('docs/meetup_delete.yml')
     def delete(this_user, self, id):
         meetup = MeetUpModel.get_by_id(id)

--- a/app/api/v1/views/meetups.py
+++ b/app/api/v1/views/meetups.py
@@ -87,6 +87,8 @@ class MeetUpItem(Resource):
                 "Status": 404,
                 "Error": "Meetup non-existent"
             }, 404
+        else:
+            MeetUpModel.delete(id)
         return {
             "Status": 200,
             "Message": "MeetUp deleted"

--- a/app/api/v1/views/meetups.py
+++ b/app/api/v1/views/meetups.py
@@ -81,7 +81,7 @@ class MeetUpItem(Resource):
     @auth_required
     @swag_from('docs/meetup_delete.yml')
     def delete(this_user, self, id):
-        meetup = MeetUpModel.get_by_id(id)
+        meetup = MeetUpModel.get_by_id(id, obj=True)
         if not meetup:
             return {
                 "Status": 404,

--- a/app/api/v1/views/rsvp.py
+++ b/app/api/v1/views/rsvp.py
@@ -99,21 +99,6 @@ class Rsvp(Resource):
         if username and UserModel.get_by_name(username):
             query_parameter = UserModel.get_by_name(username).id
 
-        # Handle these verifications in wrapper
-        """
-        else:
-            return {
-                "Status": 400,
-                "Error": "Username not registered. Provide a valid username"
-            }, 400
-
-        if query_parameter == 'id' and not UserModel.get_by_id(id):
-            return {
-                "Status": 400,
-                "Error": "User id does not exist. Provide a valid id"
-            }, 400
-        """
-
         rsvps = RsvpModel.get_all_rsvps(obj=True)
 
         users_rsvps = [rsvp for rsvp in rsvps

--- a/app/api/v1/views/rsvp.py
+++ b/app/api/v1/views/rsvp.py
@@ -88,11 +88,6 @@ class Rsvp(Resource):
 
         query_parameter = next((item for item in [id, username]
                                 if item is not None), None)
-        if not query_parameter:
-            return {
-                "Status": 400,
-                "Error": "Provide a valid username or user id"
-            }, 400
 
         # Get user id
         # Rsvp stores user by id

--- a/app/api/v1/views/user.py
+++ b/app/api/v1/views/user.py
@@ -105,15 +105,7 @@ class UserLogout(Resource):
     @swag_from('docs/auth_logout.yml')
     def delete(this_user, self):
         payload = get_raw_auth()
-
-        if not Token.check_if_blacklisted(payload):
-            Token(payload)
-        else:
-            return {
-                "Status": 403,
-                "Message": f"You must be logged in to be able to log out"
-            }, 403
-
+        Token(payload)  # Blaclist current user token
         return {
             "Status": "Success",
             "Message": f"Logout {get_auth_identity()}"

--- a/app/tests/v1/base_test.py
+++ b/app/tests/v1/base_test.py
@@ -51,6 +51,16 @@ class BaseTestCase(unittest.TestCase):
         userH = user_res.get_json().get('Data')[0].get('token')
         self.admin_auth = {"Authorization": "Bearer " + userH.split("'")[1]}
 
+        self.client.post('api/v1/meetups',
+                         content_type='application/json',
+                         data=json.dumps(dict(
+                             topic="Meats can Happen",
+                             location="Over Here",
+                             tags=['jump', 'eat', 'wake'],
+                             happeningOn='2019-09-09T20:00:00'
+                         )),
+                         headers=self.admin_auth)
+
     def post(self, path, data=None, headers=None):
 
         if not headers:

--- a/app/tests/v1/meetup_test.py
+++ b/app/tests/v1/meetup_test.py
@@ -95,6 +95,24 @@ class MeetUpTests(BaseTestCase):
                                  headers=self.admin_auth)
         self.assertEqual(res.status_code, 404)
 
+    def test_delete_missing_meetup_with_bad_auth_header(self):
+        res = self.client.delete('api/v1/meetups/6',
+                                 content_type='application/json',
+                                 headers={"Authorization": "Bearer "})
+        self.assertEqual(res.status_code, 400)
+
+    def test_delete_missing_meetup__bad_auth_header(self):
+        res = self.client.delete('api/v1/meetups/6',
+                                 content_type='application/json',
+                                 headers={"Authorization": "Bearer"})
+        self.assertEqual(res.status_code, 400)
+
+    def test_delete_missing_meetup__bad_auth_payload(self):
+        res = self.client.delete('api/v1/meetups/6',
+                                 content_type='application/json',
+                                 headers={"Authorization": "Bearer bad"})
+        self.assertEqual(res.status_code, 400)
+
     def test_delete_meetup(self):
 
         self.client.post('api/v1/meetups',

--- a/app/tests/v1/meetup_test.py
+++ b/app/tests/v1/meetup_test.py
@@ -83,7 +83,43 @@ class MeetUpTests(BaseTestCase):
                                data=json.dumps(dict(
                                    topic="Meats can Happen",
                                    location="Over Here",
-                                   tags=['jump', 'eat', 'wake']
+                                   tags=['jump', 'eat', 'wake'],
+                                   happeningOn='2019-09-09T20:00:00'
                                )),
                                headers=self.admin_auth)
         self.assertEqual(res.status_code, 201)
+
+    def test_delete_missing_meetup(self):
+        res = self.client.delete('api/v1/meetups/1',
+                                 content_type='application/json',
+                                 headers=self.admin_auth)
+        self.assertEqual(res.status_code, 404)
+
+    def test_delete_meetup(self):
+
+        self.client.post('api/v1/meetups',
+                         content_type='application/json',
+                         data=json.dumps(dict(
+                             topic="Meats can Happen",
+                             location="Over Here",
+                             tags=['jump', 'eat', 'wake'],
+                             happeningOn='2019-09-09T20:00:00'
+                         )),
+                         headers=self.admin_auth)
+
+        res = self.client.delete('api/v1/meetups/1',
+                                 content_type='application/json',
+                                 headers=self.admin_auth)
+        self.assertEqual(res.get_json(), 200)
+
+    def test_create_meetup_with_invalid_date(self):
+        res = self.client.post('api/v1/meetups',
+                               content_type='application/json',
+                               data=json.dumps(dict(
+                                   topic="Meats can Happen",
+                                   location="Over Here",
+                                   tags=['jump', 'eat', 'wake'],
+                                   happeningOn='2019-08-08 20'
+                               )),
+                               headers=self.admin_auth)
+        self.assertEqual(res.status_code, 400)

--- a/app/tests/v1/meetup_test.py
+++ b/app/tests/v1/meetup_test.py
@@ -87,10 +87,10 @@ class MeetUpTests(BaseTestCase):
                                    happeningOn='2019-09-09T20:00:00'
                                )),
                                headers=self.admin_auth)
-        self.assertEqual(res.status_code, 201)
+        self.assertEqual(res.status_code, 409)
 
     def test_delete_missing_meetup(self):
-        res = self.client.delete('api/v1/meetups/1',
+        res = self.client.delete('api/v1/meetups/6',
                                  content_type='application/json',
                                  headers=self.admin_auth)
         self.assertEqual(res.status_code, 404)
@@ -110,7 +110,7 @@ class MeetUpTests(BaseTestCase):
         res = self.client.delete('api/v1/meetups/1',
                                  content_type='application/json',
                                  headers=self.admin_auth)
-        self.assertEqual(res.get_json(), 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_create_meetup_with_invalid_date(self):
         res = self.client.post('api/v1/meetups',

--- a/app/tests/v1/rsvp_test.py
+++ b/app/tests/v1/rsvp_test.py
@@ -70,7 +70,7 @@ class RSVPTest(BaseTestCase):
 
         response = self.get('api/v1/meetups/7/rsvp')
 
-        self.assertEqual(response.status_code, 403,
+        self.assertEqual(response.status_code, 404,
                          msg="Fails to check current user when fetching rsvps")
 
     def test_fetch_rsvp_for_user_name(self):
@@ -84,7 +84,7 @@ class RSVPTest(BaseTestCase):
 
         response = self.get('api/v1/meetups/DomesticableNon Admin/rsvp')
 
-        self.assertEqual(response.status_code, 403,
+        self.assertEqual(response.status_code, 404,
                          msg="Fails allows unknow users\
                          to see rsvps for others")
 


### PR DESCRIPTION
#### What does this PR do?
Fix revoking if tokens in the logout endpoint
#### Description of Task to be completed?
- Ensure once a user logs out, the token cannot be reused to access a protected endpoint.
- Ensure that the the following endpoint is functional and works as intended:
##### - DELETE `api/v1/auth/logout


#### How should this be manually tested?

1. Clone this repo into your machine
``` shell
$ git clone https://github.com/hogum/qstioner-api.git
```
2. Navigate to the repo directory
``` shell
$ cd qstioner
```
3. Setup a virtual environment and install the project requirements
``` shell
$ pip3 install virtualenvwrapper
```
 ``` shell
$ source virtualenvwrapper.sh
```
``` shell
$ mkvirtuanenv pyenv && pip install -r requirements.txt 
```
4. Checkout this Bug branch:
``` shell
$ git checkout bg-revoke-auth-163178383
```
5. Test the endpoint `api/v1/auth/logout/
- First, create a user by registration
- Login this user
The endpoints for doing this are given [here](https://github.com/hogum/qstioner-api/blob/develop/README.md)
- Using the given access token, send a DELETE request to the logout endpoint with PostMan or Curl

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[163178383](https://www.pivotaltracker.com/story/show/163178383)


#### Screenshots

##### - First Logout Attempt

![screenshot from 2019-01-13 23-20-03](https://user-images.githubusercontent.com/44059971/51090132-5d4f9b00-1788-11e9-8f5a-4cf56b5bdd03.png)

##### - Second Logout attempt By the same user

![screenshot from 2019-01-13 23-20-14](https://user-images.githubusercontent.com/44059971/51090137-70626b00-1788-11e9-8ec4-f3e6bd1ff362.png)
